### PR TITLE
fix: update time parsing and formatting to use RFC3339Nano

### DIFF
--- a/streamystats/streamystats.go
+++ b/streamystats/streamystats.go
@@ -33,7 +33,7 @@ func (ct *CustomTime) UnmarshalJSON(data []byte) error {
 	}
 
 	// Parse with the expected format
-	t, err := time.Parse("2006-01-02 15:04:05.999-07", str)
+	t, err := time.Parse(time.RFC3339Nano, str)
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func (ct CustomTime) MarshalJSON() ([]byte, error) {
 	if ct.IsZero() {
 		return []byte("null"), nil
 	}
-	return []byte(`"` + ct.Format("2006-01-02 15:04:05.999-07") + `"`), nil
+	return []byte(`"` + ct.Format(time.RFC3339Nano) + `"`), nil
 }
 
 type ItemDetails struct {


### PR DESCRIPTION
**Motivation for this PR:**

I'm running jellysweep instance configured to work with streamystats. When running a `Media Cleanup` job, I get an error:

```
ERRO Job failed id=cleanup name="Media Cleanup" error="failed to decode item details response: parsing time \"2025-09-22T02:53:12.850000Z\" as \"2006-01-02 15:04:05.999-07\": cannot parse \"T02:53:12.850000Z\" as \" \""
```

This PR fixes this issue.

I tested it only with my own personal library, using streamystats as the data source, so I would greatly appreciate if someone took the time to test it with a different setup.