### PR TITLE
docs: Clarify Library name-matching in `config.yml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ leaving_collections_tv_name: "Leaving TV Shows"
 # Library-specific settings
 libraries:
 
+  # Name must match the Library name in Jellyfin
   "Movies":
     enabled: true
     cleanup_delay: 60


### PR DESCRIPTION
### What
Clarify in the example `config.yml` that library names must match the Jellyfin library name.

### Why
Issue #243 
This caused confusion for multiple users (including myself), who didn't realize the **Library names need to match**!! 
_(if they are not the Jellyfin defaults)_

### Scope
**Documentation-only** change. **No functional behavior is affected**.
