### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/jon4hz/jellysweep/security/code-scanning/30](https://github.com/jon4hz/jellysweep/security/code-scanning/30)

In general, the fix is to add an explicit `permissions:` block that grants only the scopes required by this CI workflow. Both jobs only need to read repository contents (for `actions/checkout`) and then run local Go tooling. They do not push commits, create releases, or otherwise modify GitHub resources. Therefore, `permissions: contents: read` at the workflow root is an appropriate minimal baseline. This will apply to all jobs that do not override permissions, including `lint` and `test`, satisfying the CodeQL rule and enforcing least privilege regardless of repo/org defaults.

Concretely, edit `.github/workflows/ci.yml` and insert a top‑level `permissions:` section after the `name: CI` (or anywhere at the top level before `jobs:`). Set it to:

```yaml
permissions:
  contents: read
```

No imports or additional methods are needed because this is just a YAML configuration change. Existing functionality is preserved: `actions/checkout`, `actions/setup-go`, `actions/cache`, and `go test` work with read‑only contents permissions. If you later uncomment and configure Codecov, it still doesn’t require elevated `GITHUB_TOKEN` permissions because it uploads to Codecov’s service, not back to GitHub.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
