### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/jon4hz/jellysweep/security/code-scanning/29](https://github.com/jon4hz/jellysweep/security/code-scanning/29)

To fix the problem, explicitly restrict `GITHUB_TOKEN` permissions in the workflow. Since both `lint` and `test` jobs only need to read the repository contents and use caches, you can add a top-level `permissions` block that applies to all jobs. A safe minimal setting is `contents: read`. If this workflow ever needs to read packages from GitHub Packages, you could also include `packages: read`, but there is no evidence of that in the snippet.

The best fix without changing existing functionality is:

- Add a `permissions` block at the root of `.github/workflows/ci.yml`, just below the `name:` (or below `on:` if you prefer), specifying:
  ```yaml
  permissions:
    contents: read
  ```
- Leave the jobs and steps unchanged. All existing actions (checkout, setup-go, cache, golangci-lint, go test) will continue to work with read-only `contents` access, as they don’t need to write to the repository via the token.

Concretely, in `.github/workflows/ci.yml`, insert the `permissions` block after line 2 and before line 3. No imports or additional methods are required since this is a YAML configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
