### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,9 @@ jobs:
   pre-commit:
     if: github.event.action != 'labeled' || github.event.label.name == 'pre-commit ci run'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/jon4hz/jellysweep/security/code-scanning/2](https://github.com/jon4hz/jellysweep/security/code-scanning/2)

Generally, the fix is to declare a `permissions:` block in the workflow (either at the root or for the specific job) and grant only the minimal scopes required. In this workflow, the steps only need to read source code and modify pull requests (labels), so we can restrict permissions to `contents: read` and `pull-requests: write`. No other write scopes (like `contents: write`) are needed.

The best minimal fix without changing behavior is to add a `permissions:` block under the `pre-commit` job in `.github/workflows/pre-commit.yml`. This ensures only this job is affected and it still has the rights needed for `gh pr edit` while no longer inheriting possibly broad repository defaults. Concretely, in `.github/workflows/pre-commit.yml`, after `runs-on: ubuntu-latest` (line 12), insert:

```yaml
    permissions:
      contents: read
      pull-requests: write
```

No additional methods, imports, or dependencies are needed; we are only tightening GitHub Actions token permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
