### PR TITLE
feat(database): add postgres backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,9 @@ All configuration options can be set via environment variables with the `JELLYSW
 | `JELLYSWEEP_LEAVING_COLLECTIONS_MOVIE_NAME` | `Leaving Movies`                | Name of the leaving movies collection                                                  |
 | `JELLYSWEEP_LEAVING_COLLECTIONS_TV_NAME`    | `Leaving TV Shows`              | Name of the leaving TV shows collection                                                |
 | **Database Configuration**                  |                                 |                                                                                        |
+| `JELLYSWEEP_DATABASE_TYPE`                  | `sqlite`                        | Database backend: `sqlite` or `postgres`                                               |
 | `JELLYSWEEP_DATABASE_PATH`                  | `./data/jellysweep.db`          | Path to the database file                                                              |
+| `JELLYSWEEP_DATABASE_URL`                   | *(required for postgres)*       | PostgreSQL connection URL                                                              |
 | **OIDC Authentication**                     |                                 |                                                                                        |
 | `JELLYSWEEP_AUTH_OIDC_ENABLED`              | `false`                         | Enable OIDC/SSO authentication                                                         |
 | `JELLYSWEEP_AUTH_OIDC_NAME`                 | OIDC                            | Display name on the login page                                                         |
@@ -472,7 +474,13 @@ server_url: "http://localhost:3002"
 
 # Database configuration (optional)
 database:
+  type: "sqlite"
   path: "./data/jellysweep.db"
+
+# PostgreSQL example:
+# database:
+#   type: "postgres"
+#   url: "postgres://jellysweep:password@postgres:5432/jellysweep?sslmode=disable"
 
 # Authentication (optional - if no auth is configured, web interface is accessible without authentication)
 auth:

--- a/README.md
+++ b/README.md
@@ -385,8 +385,13 @@ All configuration options can be set via environment variables with the `JELLYSW
 | `JELLYSWEEP_LEAVING_COLLECTIONS_TV_NAME`    | `Leaving TV Shows`              | Name of the leaving TV shows collection                                                |
 | **Database Configuration**                  |                                 |                                                                                        |
 | `JELLYSWEEP_DATABASE_TYPE`                  | `sqlite`                        | Database backend: `sqlite` or `postgres`                                               |
-| `JELLYSWEEP_DATABASE_PATH`                  | `./data/jellysweep.db`          | Path to the database file                                                              |
-| `JELLYSWEEP_DATABASE_URL`                   | *(required for postgres)*       | PostgreSQL connection URL                                                              |
+| `JELLYSWEEP_DATABASE_PATH`                  | `./data/jellysweep.db`          | Path to the database file (for SQLite)                                                |
+| `JELLYSWEEP_DATABASE_HOST`                  | *(required for postgres)*       | PostgreSQL server host                                                                 |
+| `JELLYSWEEP_DATABASE_PORT`                  | `5432`                          | PostgreSQL server port                                                                 |
+| `JELLYSWEEP_DATABASE_NAME`                  | *(required for postgres)*       | PostgreSQL database name                                                               |
+| `JELLYSWEEP_DATABASE_USER`                  | *(required for postgres)*       | PostgreSQL user                                                                        |
+| `JELLYSWEEP_DATABASE_PASSWORD`              | *(optional)*                    | PostgreSQL password                                                                    |
+| `JELLYSWEEP_DATABASE_SSL_MODE`              | `disable`                       | PostgreSQL SSL mode                                                                    |
 | **OIDC Authentication**                     |                                 |                                                                                        |
 | `JELLYSWEEP_AUTH_OIDC_ENABLED`              | `false`                         | Enable OIDC/SSO authentication                                                         |
 | `JELLYSWEEP_AUTH_OIDC_NAME`                 | OIDC                            | Display name on the login page                                                         |
@@ -480,7 +485,12 @@ database:
 # PostgreSQL example:
 # database:
 #   type: "postgres"
-#   url: "postgres://jellysweep:password@postgres:5432/jellysweep?sslmode=disable"
+#   host: "postgres"
+#   port: 5432
+#   name: "jellysweep"
+#   user: "jellysweep"
+#   password: "password"
+#   ssl_mode: "disable"
 
 # Authentication (optional - if no auth is configured, web interface is accessible without authentication)
 auth:

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -34,12 +34,7 @@ func startServer(cmd *cobra.Command, _ []string) {
 		log.Fatal("failed to load config", "error", err)
 	}
 
-	exists, err := dbFileExists(cfg.Database.Path)
-	if err != nil {
-		log.Fatal("failed to check database file", "error", err)
-	}
-
-	db, err := database.New(cfg.Database.Path)
+	db, isNewDatabase, err := database.New(cfg.Database)
 	if err != nil {
 		log.Fatal("failed to initialize database", "error", err)
 	}
@@ -47,7 +42,7 @@ func startServer(cmd *cobra.Command, _ []string) {
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
-	engine, err := engine.New(cfg, db, !exists)
+	engine, err := engine.New(cfg, db, isNewDatabase)
 	if err != nil {
 		log.Fatal("failed to create engine", "error", err)
 	}
@@ -97,15 +92,4 @@ func startServer(cmd *cobra.Command, _ []string) {
 	if err := engine.Close(); err != nil {
 		log.Error("engine shutdown error", "error", err)
 	}
-}
-
-func dbFileExists(path string) (bool, error) {
-	_, err := os.Stat(path)
-	if err == nil {
-		return true, nil
-	}
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	return false, err
 }

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/xhit/go-simple-mail/v2 v2.16.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
+	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
 )
 
@@ -88,6 +89,10 @@ require (
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gorilla/sessions v1.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/pgx/v5 v5.6.0 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -152,6 +152,14 @@ github.com/gorilla/sessions v1.4.0 h1:kpIYOp/oi6MG/p5PgxApU8srsSw9tuFbt46Lt7auzq
 github.com/gorilla/sessions v1.4.0/go.mod h1:FLWm50oby91+hl7p/wRxDth9bWSuk0qVL2emc7lT5ik=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
+github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgx/v5 v5.6.0 h1:SWJzexBzPL5jb0GEsrPMLIsi/3jOo7RHlzTjcAeDrPY=
+github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgtQdTw=
+github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
+github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
@@ -260,6 +268,7 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
@@ -395,6 +404,8 @@ gopkg.in/validator.v2 v2.0.1/go.mod h1:lIUZBlB3Im4s/eYp39Ry/wkR02yOPhZ9IwIRBjuPu
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/driver/postgres v1.6.0 h1:2dxzU8xJ+ivvqTRph34QX+WrRaJlmfyPqXmoGVjMBa4=
+gorm.io/driver/postgres v1.6.0/go.mod h1:vUw0mrGgrTK+uPHEhAdV4sfFELrByKVGnaVRkXDhtWo=
 gorm.io/gorm v1.31.1 h1:7CA8FTFz/gRfgqgpeKIBcervUn3xSyPUmr6B2WXJ7kg=
 gorm.io/gorm v1.31.1/go.mod h1:XyQVbO2k6YkOis7C2437jSit3SsDK72s7n7rsSHd+Gs=
 modernc.org/libc v1.22.5 h1:91BNch/e5B0uPbJFgqbxXuOnxBQjlS//icfQEGmvyjE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,13 @@ const (
 	CacheTypeRedis  CacheType = "redis"
 )
 
+type DatabaseType string
+
+const (
+	DatabaseTypeSQLite   DatabaseType = "sqlite"
+	DatabaseTypePostgres DatabaseType = "postgres"
+)
+
 type CleanupMode string
 
 const (
@@ -156,8 +163,12 @@ type JellyfinAuthConfig struct {
 
 // DatabaseConfig holds the database configuration.
 type DatabaseConfig struct {
+	// Type is the database backend to use. Options: "sqlite", "postgres".
+	Type DatabaseType `yaml:"type" mapstructure:"type"`
 	// Path is the path to the database file.
 	Path string `yaml:"path" mapstructure:"path"`
+	// URL is the database connection URL. Required when Type is "postgres".
+	URL string `yaml:"url" mapstructure:"url"`
 }
 
 // EmailConfig holds the email notification configuration.
@@ -448,7 +459,9 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("auth.jellyfin.enabled", true)
 
 	// Database defaults
+	v.SetDefault("database.type", DatabaseTypeSQLite)
 	v.SetDefault("database.path", "./data/jellysweep.db")
+	v.SetDefault("database.url", "")
 
 	// Cache defaults
 	v.SetDefault("cache.type", CacheTypeMemory) // Default to in-memory
@@ -530,6 +543,11 @@ func bindNestedEnv(v *viper.Viper) {
 	v.MustBindEnv("jellyfin.url", "JELLYSWEEP_JELLYFIN_URL")
 	v.MustBindEnv("jellyfin.api_key", "JELLYSWEEP_JELLYFIN_API_KEY")
 	v.MustBindEnv("jellyfin.timeout", "JELLYSWEEP_JELLYFIN_TIMEOUT")
+
+	// Database
+	v.MustBindEnv("database.type", "JELLYSWEEP_DATABASE_TYPE")
+	v.MustBindEnv("database.path", "JELLYSWEEP_DATABASE_PATH")
+	v.MustBindEnv("database.url", "JELLYSWEEP_DATABASE_URL")
 }
 
 // validateConfig validates the configuration.
@@ -573,6 +591,30 @@ func validateConfig(c *Config) error {
 
 	if c.SessionKey == "" {
 		return fmt.Errorf("session key is required")
+	}
+
+	if c.Database == nil {
+		return fmt.Errorf("missing database config")
+	}
+	if c.Database.Type == "" {
+		c.Database.Type = DatabaseTypeSQLite
+	}
+	switch c.Database.Type {
+	case DatabaseTypeSQLite:
+		if c.Database.Path == "" {
+			return fmt.Errorf("database path is required when database type is sqlite")
+		}
+	case DatabaseTypePostgres:
+		if c.Database.URL == "" {
+			return fmt.Errorf("database URL is required when database type is postgres")
+		}
+	default:
+		return fmt.Errorf(
+			"invalid database type %q: must be one of %q, %q",
+			c.Database.Type,
+			DatabaseTypeSQLite,
+			DatabaseTypePostgres,
+		)
 	}
 
 	if len(c.Libraries) == 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,8 +167,18 @@ type DatabaseConfig struct {
 	Type DatabaseType `yaml:"type" mapstructure:"type"`
 	// Path is the path to the database file.
 	Path string `yaml:"path" mapstructure:"path"`
-	// URL is the database connection URL. Required when Type is "postgres".
-	URL string `yaml:"url" mapstructure:"url"`
+	// Host is the PostgreSQL server host.
+	Host string `yaml:"host" mapstructure:"host"`
+	// Port is the PostgreSQL server port.
+	Port int `yaml:"port" mapstructure:"port"`
+	// Name is the PostgreSQL database name.
+	Name string `yaml:"name" mapstructure:"name"`
+	// User is the PostgreSQL user.
+	User string `yaml:"user" mapstructure:"user"`
+	// Password is the PostgreSQL password.
+	Password string `yaml:"password" mapstructure:"password"`
+	// SSLMode is the PostgreSQL sslmode connection option.
+	SSLMode string `yaml:"ssl_mode" mapstructure:"ssl_mode"`
 }
 
 // EmailConfig holds the email notification configuration.
@@ -461,7 +471,12 @@ func setDefaults(v *viper.Viper) {
 	// Database defaults
 	v.SetDefault("database.type", DatabaseTypeSQLite)
 	v.SetDefault("database.path", "./data/jellysweep.db")
-	v.SetDefault("database.url", "")
+	v.SetDefault("database.host", "")
+	v.SetDefault("database.port", 5432)
+	v.SetDefault("database.name", "")
+	v.SetDefault("database.user", "")
+	v.SetDefault("database.password", "")
+	v.SetDefault("database.ssl_mode", "disable")
 
 	// Cache defaults
 	v.SetDefault("cache.type", CacheTypeMemory) // Default to in-memory
@@ -547,7 +562,12 @@ func bindNestedEnv(v *viper.Viper) {
 	// Database
 	v.MustBindEnv("database.type", "JELLYSWEEP_DATABASE_TYPE")
 	v.MustBindEnv("database.path", "JELLYSWEEP_DATABASE_PATH")
-	v.MustBindEnv("database.url", "JELLYSWEEP_DATABASE_URL")
+	v.MustBindEnv("database.host", "JELLYSWEEP_DATABASE_HOST")
+	v.MustBindEnv("database.port", "JELLYSWEEP_DATABASE_PORT")
+	v.MustBindEnv("database.name", "JELLYSWEEP_DATABASE_NAME")
+	v.MustBindEnv("database.user", "JELLYSWEEP_DATABASE_USER")
+	v.MustBindEnv("database.password", "JELLYSWEEP_DATABASE_PASSWORD")
+	v.MustBindEnv("database.ssl_mode", "JELLYSWEEP_DATABASE_SSL_MODE")
 }
 
 // validateConfig validates the configuration.
@@ -605,8 +625,26 @@ func validateConfig(c *Config) error {
 			return fmt.Errorf("database path is required when database type is sqlite")
 		}
 	case DatabaseTypePostgres:
-		if c.Database.URL == "" {
-			return fmt.Errorf("database URL is required when database type is postgres")
+		if c.Database.Host == "" {
+			return fmt.Errorf("database host is required when database type is postgres")
+		}
+		if c.Database.Name == "" {
+			return fmt.Errorf("database name is required when database type is postgres")
+		}
+		if c.Database.User == "" {
+			return fmt.Errorf("database user is required when database type is postgres")
+		}
+		if c.Database.Port <= 0 {
+			return fmt.Errorf("database port must be greater than 0 when database type is postgres")
+		}
+		if c.Database.Port > 65535 {
+			return fmt.Errorf("database port must be less than or equal to 65535 when database type is postgres")
+		}
+		switch c.Database.SSLMode {
+		case "", "disable", "allow", "prefer", "require", "verify-ca", "verify-full":
+			// valid
+		default:
+			return fmt.Errorf("invalid database ssl_mode %q", c.Database.SSLMode)
 		}
 	default:
 		return fmt.Errorf(

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/glebarez/sqlite"
+	"github.com/jon4hz/jellysweep/internal/config"
+	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
@@ -15,10 +17,20 @@ type Client struct {
 }
 
 // New creates a new database connection and performs migrations.
-func New(dbpath string) (*Client, error) {
-	db, err := gorm.Open(sqlite.Open(dbpath), &gorm.Config{})
+func New(cfg *config.DatabaseConfig) (*Client, bool, error) {
+	dialector, err := dialectorForConfig(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect database: %w", err)
+		return nil, false, err
+	}
+
+	db, err := gorm.Open(dialector, &gorm.Config{})
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to connect database: %w", err)
+	}
+
+	isNew, err := isNewDatabase(db)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to inspect database schema: %w", err)
 	}
 
 	if err := db.AutoMigrate(
@@ -31,8 +43,27 @@ func New(dbpath string) (*Client, error) {
 		&EmailSettings{},
 		&HistoryEvent{},
 	); err != nil {
-		return nil, fmt.Errorf("failed to migrate database: %w", err)
+		return nil, false, fmt.Errorf("failed to migrate database: %w", err)
 	}
 
-	return &Client{db: db}, nil
+	return &Client{db: db}, isNew, nil
+}
+
+func dialectorForConfig(cfg *config.DatabaseConfig) (gorm.Dialector, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("missing database config")
+	}
+
+	switch cfg.Type {
+	case "", config.DatabaseTypeSQLite:
+		return sqlite.Open(cfg.Path), nil
+	case config.DatabaseTypePostgres:
+		return postgres.Open(cfg.URL), nil
+	default:
+		return nil, fmt.Errorf("unsupported database type %q", cfg.Type)
+	}
+}
+
+func isNewDatabase(db *gorm.DB) (bool, error) {
+	return !db.Migrator().HasTable(&Media{}), nil
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -28,10 +28,7 @@ func New(cfg *config.DatabaseConfig) (*Client, bool, error) {
 		return nil, false, fmt.Errorf("failed to connect database: %w", err)
 	}
 
-	isNew, err := isNewDatabase(db)
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to inspect database schema: %w", err)
-	}
+	isNew := isNewDatabase(db)
 
 	if err := db.AutoMigrate(
 		&Media{},
@@ -64,6 +61,6 @@ func dialectorForConfig(cfg *config.DatabaseConfig) (gorm.Dialector, error) {
 	}
 }
 
-func isNewDatabase(db *gorm.DB) (bool, error) {
-	return !db.Migrator().HasTable(&Media{}), nil
+func isNewDatabase(db *gorm.DB) bool {
+	return !db.Migrator().HasTable(&Media{})
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -2,6 +2,9 @@ package database
 
 import (
 	"fmt"
+	"net"
+	"net/url"
+	"strconv"
 
 	"github.com/glebarez/sqlite"
 	"github.com/jon4hz/jellysweep/internal/config"
@@ -55,10 +58,34 @@ func dialectorForConfig(cfg *config.DatabaseConfig) (gorm.Dialector, error) {
 	case "", config.DatabaseTypeSQLite:
 		return sqlite.Open(cfg.Path), nil
 	case config.DatabaseTypePostgres:
-		return postgres.Open(cfg.URL), nil
+		return postgres.Open(postgresDSNForConfig(cfg)), nil
 	default:
 		return nil, fmt.Errorf("unsupported database type %q", cfg.Type)
 	}
+}
+
+func postgresDSNForConfig(cfg *config.DatabaseConfig) string {
+	sslMode := cfg.SSLMode
+	if sslMode == "" {
+		sslMode = "disable"
+	}
+
+	u := &url.URL{
+		Scheme: "postgres",
+		Host:   net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port)),
+		Path:   cfg.Name,
+	}
+	if cfg.Password != "" {
+		u.User = url.UserPassword(cfg.User, cfg.Password)
+	} else {
+		u.User = url.User(cfg.User)
+	}
+
+	q := u.Query()
+	q.Set("sslmode", sslMode)
+	u.RawQuery = q.Encode()
+
+	return u.String()
 }
 
 func isNewDatabase(db *gorm.DB) bool {


### PR DESCRIPTION
## Summary

Adds PostgreSQL as an optional database backend while keeping SQLite as the default.

## PostgreSQL support

PostgreSQL is useful for deployments that want a centralized database with stronger concurrency, easier backups, external monitoring, and standard container/orchestration workflows.

SQLite remains the default, so existing setups continue to work unchanged.

## Changes

- Add `database.type` with `sqlite` and `postgres` support.
- Add separate PostgreSQL connection settings:
  - `database.host`
  - `database.port`
  - `database.name`
  - `database.user`
  - `database.password`
  - `database.ssl_mode`
- Keep `database.path` for SQLite.
- Add the GORM PostgreSQL driver.
- Update database initialization to select the configured backend.
- Update README configuration docs with the new database options.

## Environment variables

PostgreSQL can be configured with:

- `JELLYSWEEP_DATABASE_TYPE=postgres`
- `JELLYSWEEP_DATABASE_HOST`
- `JELLYSWEEP_DATABASE_PORT`
- `JELLYSWEEP_DATABASE_NAME`
- `JELLYSWEEP_DATABASE_USER`
- `JELLYSWEEP_DATABASE_PASSWORD`
- `JELLYSWEEP_DATABASE_SSL_MODE`

## Validation

```bash
go test ./...
```
