### PR TITLE
feat: add unmonitor option for arr deletions (default: true, all modes)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -310,6 +310,10 @@ type SonarrConfig struct {
 	APIKey string `yaml:"api_key" mapstructure:"api_key"`
 	// Timeout is the HTTP client timeout in seconds.
 	Timeout int `yaml:"timeout" mapstructure:"timeout"`
+	// Unmonitor controls whether deleted items are automatically unmonitored
+	// in Sonarr before deletion. When enabled, episodes with files are
+	// unmonitored to prevent re-downloading.
+	Unmonitor bool `yaml:"unmonitor" mapstructure:"unmonitor"`
 }
 
 // RadarrConfig holds the configuration for the Radarr server.
@@ -320,6 +324,9 @@ type RadarrConfig struct {
 	APIKey string `yaml:"api_key" mapstructure:"api_key"`
 	// Timeout is the HTTP client timeout in seconds.
 	Timeout int `yaml:"timeout" mapstructure:"timeout"`
+	// Unmonitor controls whether deleted items are automatically unmonitored
+	// to prevent them from being re-downloaded.
+	Unmonitor bool `yaml:"unmonitor" mapstructure:"unmonitor"`
 }
 
 // JellystatConfig holds the configuration for the Jellystat server.
@@ -506,6 +513,10 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("ntfy.password", "")
 	v.SetDefault("ntfy.token", "")
 	v.SetDefault("ntfy.timeout", 30)
+
+	// Sonarr / Radarr defaults
+	v.SetDefault("sonarr.unmonitor", true)
+	v.SetDefault("radarr.unmonitor", true)
 
 	// Gravatar defaults
 	v.SetDefault("gravatar.enabled", false)

--- a/internal/engine/arr/arr.go
+++ b/internal/engine/arr/arr.go
@@ -30,6 +30,9 @@ type Arrer interface {
 	GetItems(ctx context.Context, jellyfinItems []JellyfinItem) ([]MediaItem, error)
 	DeleteMedia(ctx context.Context, arrID int32, title string) error
 
+	// UnmonitorMedia unmonitors a media item in the arr to prevent re-download.
+	UnmonitorMedia(ctx context.Context, arrID int32, title string) error
+
 	// Bulk tag resets/cleanup
 	ResetTags(ctx context.Context, additionalTags []string) error
 	CleanupAllTags(ctx context.Context, additionalTags []string) error

--- a/internal/engine/arr/radarr/radarr.go
+++ b/internal/engine/arr/radarr/radarr.go
@@ -255,6 +255,29 @@ func (r *Radarr) DeleteMedia(ctx context.Context, movieID int32, title string) e
 	return nil
 }
 
+// UnmonitorMedia unmonitors a Radarr movie to prevent it from being re-downloaded.
+func (r *Radarr) UnmonitorMedia(ctx context.Context, movieID int32, title string) error {
+	if r.cfg.DryRun {
+		log.Info("dry run: would unmonitor Radarr movie", "title", title)
+		return nil
+	}
+
+	resource := radarrAPI.NewMovieEditorResource()
+	resource.SetMovieIds([]int32{movieID})
+	resource.SetMonitored(false)
+
+	resp, err := r.client.MovieEditorAPI.PutMovieEditor(r.radarrAuthCtx(ctx)).
+		MovieEditorResource(*resource).
+		Execute()
+	if err != nil {
+		return fmt.Errorf("failed to unmonitor Radarr movie %s: %w", title, err)
+	}
+	defer resp.Body.Close() //nolint: errcheck
+
+	log.Info("unmonitored Radarr movie to prevent redownload", "title", title)
+	return nil
+}
+
 func (r *Radarr) ResetTags(ctx context.Context, additionalTags []string) error {
 	movies, err := r.getItems(ctx)
 	if err != nil {

--- a/internal/engine/arr/sonarr/sonarr.go
+++ b/internal/engine/arr/sonarr/sonarr.go
@@ -258,6 +258,47 @@ func (s *Sonarr) ensureTagExists(ctx context.Context, deleteTagLabel string) err
 	return nil
 }
 
+// UnmonitorMedia unmonitors all episodes with files for a Sonarr series
+// to prevent them from being re-downloaded after deletion.
+func (s *Sonarr) UnmonitorMedia(ctx context.Context, seriesID int32, title string) error {
+	episodes, err := s.getEpisodes(ctx, seriesID)
+	if err != nil {
+		return fmt.Errorf("failed to get episodes for series %s: %w", title, err)
+	}
+
+	if s.cfg.DryRun {
+		log.Info("dry run: would unmonitor episodes for series", "title", title, "count", len(episodes))
+		return nil
+	}
+
+	var episodesToUnmonitor []int32
+	for _, ep := range episodes {
+		if ep.GetHasFile() {
+			episodesToUnmonitor = append(episodesToUnmonitor, ep.GetId())
+		}
+	}
+
+	if len(episodesToUnmonitor) == 0 {
+		return nil
+	}
+
+	monitored := false
+	resource := sonarrAPI.NewEpisodesMonitoredResource()
+	resource.SetEpisodeIds(episodesToUnmonitor)
+	resource.SetMonitored(monitored)
+
+	resp, err := s.client.EpisodeAPI.PutEpisodeMonitor(s.sonarrAuthCtx(ctx)).
+		EpisodesMonitoredResource(*resource).
+		Execute()
+	if err != nil {
+		return fmt.Errorf("failed to unmonitor %d episodes for series %s: %w", len(episodesToUnmonitor), title, err)
+	}
+	defer resp.Body.Close() //nolint: errcheck
+
+	log.Info("unmonitored episodes to prevent redownload", "title", title, "count", len(episodesToUnmonitor))
+	return nil
+}
+
 // ResetTags removes jellysweep-related tags (and additionalTags) from all series.
 func (s *Sonarr) ResetTags(ctx context.Context, additionalTags []string) error {
 	series, err := s.getItems(ctx)

--- a/internal/engine/cleanup.go
+++ b/internal/engine/cleanup.go
@@ -40,6 +40,13 @@ func (e *Engine) cleanupMedia(ctx context.Context) error {
 				log.Warn("Sonarr client not configured, cannot delete TV show", "title", item.Title)
 				continue
 			}
+			// Unmonitor before deletion when enabled
+			if e.cfg.Sonarr.Unmonitor {
+				if err := e.sonarr.UnmonitorMedia(ctx, item.ArrID, item.Title); err != nil {
+					log.Error("failed to unmonitor Sonarr media", "title", item.Title, "error", err)
+					// Continue even if unmonitor fails
+				}
+			}
 			if err := e.sonarr.DeleteMedia(ctx, item.ArrID, item.Title); err != nil {
 				log.Error("failed to delete Sonarr media", "title", item.Title, "error", err)
 				continue
@@ -61,6 +68,12 @@ func (e *Engine) cleanupMedia(ctx context.Context) error {
 			if e.radarr == nil {
 				log.Warn("Radarr client not configured, cannot delete movie", "title", item.Title)
 				continue
+			}
+			// Unmonitor before deletion when enabled
+			if e.cfg.Radarr.Unmonitor {
+				if err := e.radarr.UnmonitorMedia(ctx, item.ArrID, item.Title); err != nil {
+					log.Error("failed to unmonitor Radarr media", "title", item.Title, "error", err)
+				}
 			}
 			if err := e.radarr.DeleteMedia(ctx, item.ArrID, item.Title); err != nil {
 				log.Error("failed to delete Radarr media", "title", item.Title, "error", err)


### PR DESCRIPTION
## Summary

Adds a config-level `unmonitor` toggle to both `SonarrConfig` and `RadarrConfig` (defaults to `true`). When enabled, Jellysweep unmonitors items in Radarr/Sonarr **before** deleting them, preventing automatic re-download.

All cleanup modes respect this param — `all`, `keep_episodes`, and `keep_seasons`.

## Changes

### Config (`internal/config/config.go`)
- `Unmonitor bool` (default: `true`) on both `SonarrConfig` and `RadarrConfig`
- Set via `v.SetDefault("sonarr.unmonitor", true)` and `v.SetDefault("radarr.unmonitor", true)`

### Interface (`internal/engine/arr/arr.go`)
- `UnmonitorMedia(ctx, arrID int32, title string) error` on the `Arrer` interface

### Radarr (`internal/engine/arr/radarr/radarr.go`)
- Uses `MovieEditorAPI.PutMovieEditor` with `monitored=false`

### Sonarr (`internal/engine/arr/sonarr/sonarr.go`)
- Unmonitors individual episodes that have files via `EpisodeAPI.PutEpisodeMonitor`

### Cleanup engine (`internal/engine/cleanup.go`)
- Calls `UnmonitorMedia` before `DeleteMedia` for both Radarr and Sonarr when `unmonitor` is enabled
- No cleanup_mode guard — consistent across all modes

## Example config

```yaml
sonarr:
  url: http://192.168.1.10:8989
  api_key: "..."
  unmonitor: true   # default, can omit

radarr:
  url: http://192.168.1.10:7878
  api_key: "..."
  unmonitor: true   # default, can omit
```

## Why this matters

Without this, Radarr/Sonarr re-download items Jellysweep deletes → endless disk-fill loop. The only workaround was a cron script. Now it happens automatically with sensible defaults.