### PR TITLE
fix: dashboard infinite scroll re-appending the same batch of items

### DIFF
--- a/web/templates/components/media-grid.templ
+++ b/web/templates/components/media-grid.templ
@@ -311,6 +311,22 @@ script MediaGridScript() {
 				return;
 			}
 
+			// Advance the cursor and hasMoreData synchronously, before the render
+			// delay below. renderItems() staggers each card's skeleton->content
+			// swap with its own per-item setTimeout, so the grid is still
+			// growing/reflowing well after this function returns. That reflow can
+			// nudge the scroll sentinel back into the IntersectionObserver's
+			// rootMargin and fire loadMore() again. If the cursor only advanced
+			// inside the delayed callback below, that re-entrant call would still
+			// see the old startIndex/endIndex and re-append the same batch,
+			// producing an endless repeat of the same items while scrolling.
+			// Locking in the cursor here means any re-entrant call always moves
+			// on to the next slice instead.
+			for (let i = startIndex; i < endIndex; i++) {
+				this.renderedItems.add(i);
+			}
+			this.hasMoreData = endIndex < this.filteredItems.length;
+
 			// Add progressive loading delay for smoother experience
 			const screenWidth = window.innerWidth;
 			const isMobile = screenWidth < 640;
@@ -318,14 +334,6 @@ script MediaGridScript() {
 
 			setTimeout(() => {
 				this.renderItems(newItems, true); // true = append
-
-				// Update rendered items tracking
-				for (let i = startIndex; i < endIndex; i++) {
-					this.renderedItems.add(i);
-				}
-
-				// Check if we have more data
-				this.hasMoreData = endIndex < this.filteredItems.length;
 
 				this.hideScrollLoading();
 				this.isLoading = false;

--- a/web/templates/components/media-grid_templ.go
+++ b/web/templates/components/media-grid_templ.go
@@ -55,8 +55,8 @@ func GetUniqueLibraries(items []database.Media) []string {
 
 func MediaGridScript() templ.ComponentScript {
 	return templ.ComponentScript{
-		Name: `__templ_MediaGridScript_13cd`,
-		Function: `function __templ_MediaGridScript_13cd(){class MediaGridManager {
+		Name: `__templ_MediaGridScript_1562`,
+		Function: `function __templ_MediaGridScript_1562(){class MediaGridManager {
 		constructor(containerId, options = {}) {
 			this.containerId = containerId;
 			this.container = document.getElementById(containerId);
@@ -321,6 +321,22 @@ func MediaGridScript() templ.ComponentScript {
 				return;
 			}
 
+			// Advance the cursor and hasMoreData synchronously, before the render
+			// delay below. renderItems() staggers each card's skeleton->content
+			// swap with its own per-item setTimeout, so the grid is still
+			// growing/reflowing well after this function returns. That reflow can
+			// nudge the scroll sentinel back into the IntersectionObserver's
+			// rootMargin and fire loadMore() again. If the cursor only advanced
+			// inside the delayed callback below, that re-entrant call would still
+			// see the old startIndex/endIndex and re-append the same batch,
+			// producing an endless repeat of the same items while scrolling.
+			// Locking in the cursor here means any re-entrant call always moves
+			// on to the next slice instead.
+			for (let i = startIndex; i < endIndex; i++) {
+				this.renderedItems.add(i);
+			}
+			this.hasMoreData = endIndex < this.filteredItems.length;
+
 			// Add progressive loading delay for smoother experience
 			const screenWidth = window.innerWidth;
 			const isMobile = screenWidth < 640;
@@ -328,14 +344,6 @@ func MediaGridScript() templ.ComponentScript {
 
 			setTimeout(() => {
 				this.renderItems(newItems, true); // true = append
-
-				// Update rendered items tracking
-				for (let i = startIndex; i < endIndex; i++) {
-					this.renderedItems.add(i);
-				}
-
-				// Check if we have more data
-				this.hasMoreData = endIndex < this.filteredItems.length;
 
 				this.hideScrollLoading();
 				this.isLoading = false;
@@ -867,8 +875,8 @@ func MediaGridScript() templ.ComponentScript {
 	// Export the class for use by other scripts
 	window.MediaGridManager = MediaGridManager;
 }`,
-		Call:       templ.SafeScript(`__templ_MediaGridScript_13cd`),
-		CallInline: templ.SafeScriptInline(`__templ_MediaGridScript_13cd`),
+		Call:       templ.SafeScript(`__templ_MediaGridScript_1562`),
+		CallInline: templ.SafeScriptInline(`__templ_MediaGridScript_1562`),
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #352. The media dashboard's infinite scroll can get stuck repeating the same batch of items indefinitely while scrolling.

## Root cause

`MediaGridManager.loadMore()` (`web/templates/components/media-grid.templ`) only advanced its rendering cursor (`this.renderedItems`) and reset `this.isLoading` *inside* the `setTimeout(..., delay)` callback that kicks off `renderItems()`. But `renderItems()` itself staggers each card's skeleton-to-content swap with its own per-item `setTimeout` (`index * 50ms`), so the grid keeps growing/reflowing well after `loadMore()`'s own callback has already returned and cleared `isLoading`.

Any layout reflow during that window (for example, the dashboard's default request-status filter running ~10ms after load, which briefly empties the grid via `clearGrid()`) can nudge the scroll sentinel back into the `IntersectionObserver`'s `rootMargin` and fire `loadMore()` again. Since the cursor hadn't advanced yet, the re-entrant call computes the exact same `startIndex`/`endIndex`, re-slices the same items from `filteredItems`, and appends them again. If the reflow keeps happening (it does, since every subsequent stagger-swap reflows too), the same batch repeats indefinitely.

## Fix

Advance `renderedItems` and `hasMoreData` synchronously as soon as `loadMore()` decides which slice to load, before the render `setTimeout`. Any re-entrant call (spurious or otherwise) then always sees the next slice instead of the stale one, so it moves forward instead of repeating.

## Verification

- Confirmed via direct sqlite3 inspection of a running instance's `jellysweep.db` that the underlying `media` table had zero duplicate rows (active row count, `COUNT(DISTINCT jellyfin_id)`, and `COUNT(DISTINCT title)` all matched) — the bug is purely in the frontend rendering cursor, not the data layer.
- `go tool templ generate` regenerates `media-grid_templ.go` cleanly from the patched `.templ` source.
- `go build ./...` and `go vet ./...` pass.
- No existing automated test covers this inline dashboard JS (no JS test harness in the repo), so verification here is via build/vet plus the logical trace above.

## Test plan

- [ ] Load the dashboard with 100+ scheduled items and scroll continuously; confirm each batch of cards appears exactly once with no repeats
- [ ] Confirm the default "Unrequested" filter (which re-renders shortly after initial load) doesn't reintroduce the repeat
- [ ] `go build ./...` / `go vet ./...` clean