### PR TITLE
feat: Add support for Jellyfin 12.0 authetication headers

### DIFF
--- a/internal/api/auth/jellyfin_provider.go
+++ b/internal/api/auth/jellyfin_provider.go
@@ -31,7 +31,7 @@ func NewJellyfinProvider(cfg *config.JellyfinConfig, db database.UserDB, authCfg
 	}
 	clientConfig.UserAgent = fmt.Sprintf("Jellysweep-Auth/%s", version.Version)
 	clientConfig.DefaultHeader = map[string]string{
-		"X-Emby-Authorization": fmt.Sprintf(
+		"Authorization": fmt.Sprintf(
 			`MediaBrowser Client="Jellysweep-Auth", Device="Jellysweep", DeviceId="jellysweep-auth", Version="%s",`,
 			version.Version,
 		),


### PR DESCRIPTION
Add support for the authorization header introduced in Jellyfin 10.11. This should solve issue #395.

I've done testing against Jellyfin 12.0-rc4 and this allows Jellyfin auth to work again. 