### PR TITLE
fix(filter): match database rows by media type as well as arr ID

### DIFF
--- a/internal/filter/database_filter/filter.go
+++ b/internal/filter/database_filter/filter.go
@@ -56,9 +56,9 @@ func (f *Filter) Apply(ctx context.Context, mediaItems []arr.MediaItem) ([]arr.M
 func arrItemIsEqual(a arr.MediaItem, b database.Media) bool {
 	switch a.MediaType {
 	case models.MediaTypeMovie:
-		return a.MovieResource.GetId() == b.ArrID
+		return b.MediaType == database.MediaTypeMovie && a.MovieResource.GetId() == b.ArrID
 	case models.MediaTypeTV:
-		return a.SeriesResource.GetId() == b.ArrID
+		return b.MediaType == database.MediaTypeTV && a.SeriesResource.GetId() == b.ArrID
 	default:
 		return false
 	}

--- a/internal/filter/database_filter/filter_test.go
+++ b/internal/filter/database_filter/filter_test.go
@@ -113,3 +113,25 @@ func TestApplyIgnoresTombstones(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 1, "tombstoned items must be re-picked up")
 }
+
+func TestApplyDoesNotMatchAcrossMediaTypes(t *testing.T) {
+	// Sonarr and Radarr IDs are separate sequences. A tracked movie with
+	// arr ID 19 must not hide the series that also has arr ID 19.
+	db, _ := databasetest.New(t)
+	require.NoError(t, db.CreateMediaItems(t.Context(), []database.Media{{
+		JellyfinID:      "jf-Known Movie",
+		Title:           "Known Movie",
+		ArrID:           19,
+		MediaType:       database.MediaTypeMovie,
+		DefaultDeleteAt: time.Now().Add(24 * time.Hour),
+	}}))
+
+	f := New(db)
+	got, err := f.Apply(t.Context(), []arr.MediaItem{
+		movieItem("Known Movie", 19),
+		seriesItem("New Show", 19),
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "New Show", got[0].Title)
+}


### PR DESCRIPTION
## Problem

`arrItemIsEqual` in the Database Filter compares a candidate against every tracked row by arr ID only. Sonarr and Radarr IDs are independent sequences, so once a Radarr movie with ID N is tracked, the Sonarr series with ID N is treated as "already marked for deletion" and skipped on every run. Same the other way round.

In my instance the nightly log showed `Database Filter initial_items=312 filtered_out=234` while the DB held 185 active rows. 49 items were dropped for the wrong reason. The one I noticed: Squid Game (Sonarr id 19) hidden by Pirates of the Caribbean (Radarr id 19).

## Fix

Require `b.MediaType` to match the candidate's type in both branches. `Media.MediaType` is `not null` and the engine always sets it to `tv` or `movie` (`arrMediaToDBMediaItem`), so no tracked row loses its match.

## Test

`TestApplyDoesNotMatchAcrossMediaTypes`: a tracked movie with arr ID 19 still excludes the movie candidate and no longer excludes the series candidate with the same ID. Fails on `main`, passes with the fix.